### PR TITLE
Patch 1

### DIFF
--- a/tutorial/02-create-app.md
+++ b/tutorial/02-create-app.md
@@ -93,7 +93,7 @@ You will also create a simple JavaScript single-page application (SPA) to call t
 1. Change the current directory in your CLI to the **TestClient** directory and run the following command to start an HTTP server.
 
     ```Shell
-    dotnet serve -h "Cache-Control: no-cache, no-store, must-revalidate"
+    dotnet serve -h "Cache-Control: no-cache, no-store, must-revalidate" -p 8080
     ```
 
 1. Open your browser and navigate to `http://localhost:8080`. The page should render, but none of the buttons currently work.

--- a/tutorial/05-implement-webhook.md
+++ b/tutorial/05-implement-webhook.md
@@ -40,7 +40,7 @@ Take a moment to consider what the code in **ClientCredentialsAuthProvider.cs** 
 
 1. Replace the existing `GetAppGraphClient` function with the following.
 
-    :::code language="csharp" source="../demo/GraphTutorial/Services/GraphClientService.cs" id="AppGraphClientMembers":::
+    :::code language="csharp" source="../demo/GraphTutorial/Services/GraphClientService.cs" id="AppGraphClientFunctions":::
 
 ## Implement Notify function
 


### PR DESCRIPTION
- Add port 8080 (-p 8080) argument to dotnet serve command as without dotnet serve uses a random port which does not follow the tutorial's expectation
- Fixed id reference in code snippet that was not pointed to the right area (AppGraphClientMembers instead of AppGraphClientFunctions)